### PR TITLE
CreateDeploy k8sutil and DeploymentInput

### DIFF
--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -3,9 +3,11 @@ package k8sutil
 import (
 	"fmt"
 
+	"k8s.io/api/apps/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientv1beta1 "k8s.io/client-go/kubernetes/typed/apps/v1beta1"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -42,4 +44,63 @@ func CreateConfigMap(client clientv1.ConfigMapInterface, cm *v1.ConfigMap) error
 
 func DeleteConfigMap(client clientv1.ConfigMapInterface, cm string) error {
 	return client.Delete(cm, &meta_v1.DeleteOptions{})
+}
+
+func CreateDeployment(client clientv1beta1.DeploymentInterface, deployment *v1beta1.Deployment) error {
+	_, err := client.Create(deployment)
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type DeploymentInput struct {
+	Name            string
+	Image           string
+	ImagePullPolicy v1.PullPolicy
+	Labels          map[string]string
+	Selector        *meta_v1.LabelSelector
+	Replicas        *int32
+	Namespace       string
+	Ports           []v1.ContainerPort
+	VolumeMounts    []v1.VolumeMount
+	Resources       v1.ResourceRequirements
+	Volumes         []v1.Volume
+}
+
+func NewDeployment(i DeploymentInput) *v1beta1.Deployment {
+	return &v1beta1.Deployment{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      i.Name,
+			Labels:    i.Labels,
+			Namespace: i.Namespace,
+		},
+		Spec: v1beta1.DeploymentSpec{
+			Selector: i.Selector,
+			Replicas: i.Replicas,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Labels:    i.Labels,
+					Namespace: i.Namespace,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						v1.Container{
+							Name:            i.Name,
+							Image:           i.Image,
+							ImagePullPolicy: i.ImagePullPolicy,
+							Env:             []v1.EnvVar{},
+							Ports:           i.Ports,
+							VolumeMounts:    i.VolumeMounts,
+							Resources:       i.Resources,
+						},
+					},
+					Volumes: i.Volumes,
+				},
+			},
+		},
+	}
 }

--- a/pkg/operator/chronograf.go
+++ b/pkg/operator/chronograf.go
@@ -110,13 +110,15 @@ func (o *Operator) handleAddChronograf(obj interface{}) {
 		},
 	}
 
-	_, err := o.kubeClient.AppsV1beta1().Deployments(oret.GetNamespace()).Create(deployment)
-
+	err := k8sutil.CreateDeployment(o.kubeClient.AppsV1beta1().Deployments(oret.GetNamespace()), deployment)
 	if err != nil {
 		log.Print(err)
 	}
 
 	svc := makeChronografService(choosenName, o.config)
+	if err != nil {
+		log.Print(err)
+	}
 	err = k8sutil.CreateService(o.kubeClient.CoreV1().Services(oret.GetNamespace()), svc)
 
 	if err != nil {

--- a/pkg/operator/influxdb.go
+++ b/pkg/operator/influxdb.go
@@ -61,6 +61,52 @@ func (o *Operator) handleDeleteInfluxDB(obj interface{}) {
 	}
 }
 
+func makeInfluxDBDeployment(oret metav1.Object, deploymentName string, influxdbSpec *v1alpha1.Influxdb) *v1beta1.Deployment {
+	labels := oret.GetLabels()
+	for k, v := range influxdbSpec.GetLabels() {
+		labels[k] = v
+	}
+
+	labels["name"] = deploymentName
+	labels["resource"] = v1alpha1.InfluxDBKind
+	i := k8sutil.DeploymentInput{
+		Name:            labels["name"],
+		Image:           influxdbSpec.Spec.BaseImage,
+		ImagePullPolicy: influxdbSpec.Spec.ImagePullPolicy,
+		Labels:          labels,
+		Selector:        influxdbSpec.Spec.Selector,
+		Replicas:        influxdbSpec.Spec.Replicas,
+		Namespace:       oret.GetNamespace(),
+		Ports: []v1.ContainerPort{
+			v1.ContainerPort{
+				Name:          "http",
+				ContainerPort: 8086,
+				Protocol:      v1.ProtocolTCP,
+			},
+		},
+		VolumeMounts: []v1.VolumeMount{
+			{
+				Name:      "influxdb-config",
+				SubPath:   "config.toml",
+				MountPath: "/etc/influxdb/influxdb.conf",
+			},
+		},
+		Volumes: []v1.Volume{
+			{
+				Name: "influxdb-config",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: deploymentName,
+						},
+					},
+				},
+			},
+		},
+	}
+	return k8sutil.NewDeployment(i)
+}
+
 func (o *Operator) handleAddInfluxDB(obj interface{}) {
 	oret, ok := o.getObject(obj)
 
@@ -71,15 +117,7 @@ func (o *Operator) handleAddInfluxDB(obj interface{}) {
 
 	influxdbSpec := obj.(*v1alpha1.Influxdb)
 
-	labels := o.config.Labels
-	for k, v := range influxdbSpec.GetLabels() {
-		labels[k] = v
-	}
-
 	choosenName := fmt.Sprintf("%s-%s", v1alpha1.InfluxDBKind, oret.GetName())
-	labels["name"] = choosenName
-	labels["resource"] = v1alpha1.InfluxDBKind
-
 	config := createInfluxDBConfiguration(influxdbSpec.Spec)
 	cm, err := makeInfluxDBConfigMap(choosenName, config)
 
@@ -95,62 +133,8 @@ func (o *Operator) handleAddInfluxDB(obj interface{}) {
 		return
 	}
 
-	deployment := &v1beta1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      labels["name"],
-			Labels:    labels,
-			Namespace: oret.GetNamespace(),
-		},
-		Spec: v1beta1.DeploymentSpec{
-			Selector: influxdbSpec.Spec.Selector,
-			Replicas: influxdbSpec.Spec.Replicas,
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels:    labels,
-					Namespace: oret.GetNamespace(),
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						v1.Container{
-							Name:            oret.GetName(),
-							Image:           influxdbSpec.Spec.BaseImage,
-							ImagePullPolicy: influxdbSpec.Spec.ImagePullPolicy,
-							Env:             []v1.EnvVar{},
-							Ports: []v1.ContainerPort{
-								v1.ContainerPort{
-									Name:          "http",
-									ContainerPort: 8086,
-									Protocol:      v1.ProtocolTCP,
-								},
-							},
-							VolumeMounts: []v1.VolumeMount{
-								{
-									Name:      "influxdb-config",
-									SubPath:   "config.toml",
-									MountPath: "/etc/influxdb/influxdb.conf",
-								},
-							},
-							//Resources:    v1.ResourceRequirements{},
-						},
-					},
-					Volumes: []v1.Volume{
-						{
-							Name: "influxdb-config",
-							VolumeSource: v1.VolumeSource{
-								ConfigMap: &v1.ConfigMapVolumeSource{
-									LocalObjectReference: v1.LocalObjectReference{
-										Name: choosenName,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	_, err = o.kubeClient.AppsV1beta1().Deployments(oret.GetNamespace()).Create(deployment)
+	deployment := makeInfluxDBDeployment(oret, choosenName, influxdbSpec)
+	err = k8sutil.CreateDeployment(o.kubeClient.AppsV1beta1().Deployments(oret.GetNamespace()), deployment)
 	if err != nil {
 		log.Print(err)
 	}

--- a/pkg/operator/kapacitor.go
+++ b/pkg/operator/kapacitor.go
@@ -109,7 +109,7 @@ func (o *Operator) handleAddKapacitor(obj interface{}) {
 		},
 	}
 
-	_, err := o.kubeClient.AppsV1beta1().Deployments(oret.GetNamespace()).Create(deployment)
+	err := k8sutil.CreateDeployment(o.kubeClient.AppsV1beta1().Deployments(oret.GetNamespace()), deployment)
 	if err != nil {
 		log.Print(err)
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -8,7 +8,6 @@ import (
 	extensionsobj "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -28,20 +27,6 @@ type Operator struct {
 	influxInformer     cache.SharedIndexInformer
 	kapacitorInformer  cache.SharedIndexInformer
 	chronografInformer cache.SharedIndexInformer
-}
-
-func (o *Operator) getObject(obj interface{}) (metav1.Object, bool) {
-	ts, ok := obj.(cache.DeletedFinalStateUnknown)
-	if ok {
-		obj = ts.Obj
-	}
-
-	oret, err := meta.Accessor(obj)
-	if err != nil {
-		log.Print(err)
-		return nil, false
-	}
-	return oret, true
 }
 
 func New(options Config) *Operator {

--- a/specs/values.yaml
+++ b/specs/values.yaml
@@ -24,6 +24,8 @@ kind: chronograf
 metadata:
   name: monitor
   namespace: default
+  labels:
+    foo: bar
 spec:
   baseImage: "docker.io/chronograf:1.3"
 ---


### PR DESCRIPTION
This PR starts a refactoring around Deployment creation and deployment
configuration.

At the moment this is a core part of our operator and it's used for all
services kapacitor, chonograf, influxdb.

It started to cause trouble in terms of code readability.