### PR TITLE
Added support to configure influxdb source for chronograf

### DIFF
--- a/pkg/operator/chronograf.go
+++ b/pkg/operator/chronograf.go
@@ -82,6 +82,13 @@ func makeChronografDeployment(deploymentName string, spec *v1alpha1.Chronograf) 
 		},
 	}
 
+	if spec.Spec.InfuxDBSource.Url != "" {
+		envs = append(envs, v1.EnvVar{
+			Value: spec.Spec.InfuxDBSource.Url,
+			Name:  "INFLUXDB_URL",
+		})
+	}
+
 	i := k8sutil.DeploymentInput{
 		Name:            labels["name"],
 		Image:           spec.Spec.BaseImage,

--- a/pkg/operator/chronograf_test.go
+++ b/pkg/operator/chronograf_test.go
@@ -18,6 +18,25 @@ func TestDefaultValuesForChronografSpec(t *testing.T) {
 	}
 }
 
+func TestDeploymentWithInfluxDBSourceUrl(t *testing.T) {
+	spec := &v1alpha1.Chronograf{}
+	setDefaultSpecValues(spec)
+	spec.Spec.InfuxDBSource = v1alpha1.ChronografSource{
+		Url: "http://influxdb:8086",
+	}
+	deployment := makeChronografDeployment("hello", spec)
+	envs := deployment.Spec.Template.Spec.Containers[0].Env
+	var url string
+	for _, env := range envs {
+		if env.Name == "INFLUXDB_URL" {
+			url = env.Value
+		}
+	}
+	if url != "http://influxdb:8086" {
+		t.Error("Expected env var INFLUXDB_URL with value http://influxdb:8086 insted value is `%s`", url)
+	}
+}
+
 func TestDefaultValuesForChronografSpecPrePopulated(t *testing.T) {
 	spec := &v1alpha1.Chronograf{}
 	spec.Spec.Port = 9088

--- a/specs/values.yaml
+++ b/specs/values.yaml
@@ -28,6 +28,8 @@ metadata:
     foo: bar
 spec:
   baseImage: "docker.io/chronograf:1.3"
+  influxdb_source:
+    url: "http://influxdb-monitor.default.svc.cluster.local:8086"
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
This is a POC about how we can make this operator useful. It knows about
all the resources and we can put this source as default.

At the moment I am just happy to try network connection between InfluxDB
and Chronograf pods.